### PR TITLE
feat: endpoint mock /api/parse-invoice

### DIFF
--- a/src/app/api/parse-invoice/route.test.ts
+++ b/src/app/api/parse-invoice/route.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { POST } from "@/app/api/parse-invoice/route";
+
+describe("POST /api/parse-invoice", () => {
+  it("devuelve items mock con confianza alta para factura clara", async () => {
+    const request = new Request("http://localhost/api/parse-invoice", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ fileName: "factura-supermercado.jpg" }),
+    });
+
+    const response = await POST(request);
+    const payload = (await response.json()) as {
+      confidence: number;
+      low_confidence: boolean;
+      items: Array<{ raw_description: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.low_confidence).toBe(false);
+    expect(payload.confidence).toBeGreaterThan(0.8);
+    expect(payload.items.length).toBeGreaterThan(0);
+  });
+
+  it("marca baja confianza cuando el nombre sugiere mala calidad", async () => {
+    const request = new Request("http://localhost/api/parse-invoice", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ fileName: "ticket_blurry.png" }),
+    });
+
+    const response = await POST(request);
+    const payload = (await response.json()) as {
+      low_confidence: boolean;
+      warnings: string[];
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.low_confidence).toBe(true);
+    expect(payload.warnings[0]).toMatch(/foto mas clara/i);
+  });
+
+  it("devuelve 400 cuando falta input valido", async () => {
+    const request = new Request("http://localhost/api/parse-invoice", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+    const payload = (await response.json()) as { error: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toMatch(/entrada invalida/i);
+  });
+});

--- a/src/app/api/parse-invoice/route.ts
+++ b/src/app/api/parse-invoice/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server";
+
+type MockInvoiceItem = {
+  raw_description: string;
+  line_total: number;
+  qty?: number;
+  unit?: string;
+  confidence?: number;
+};
+
+type ParseInvoiceMockResponse = {
+  items: MockInvoiceItem[];
+  confidence: number;
+  low_confidence: boolean;
+  warnings: string[];
+};
+
+function buildMockResponse(fileName: string): ParseInvoiceMockResponse {
+  const lowered = fileName.toLowerCase();
+  const lowConfidence =
+    lowered.includes("blurry") ||
+    lowered.includes("blur") ||
+    lowered.includes("ilegible") ||
+    lowered.includes("oscura");
+
+  if (lowConfidence) {
+    return {
+      items: [
+        {
+          raw_description: "Harina (lectura parcial)",
+          line_total: 1450,
+          confidence: 0.48,
+        },
+        {
+          raw_description: "Leche (texto incompleto)",
+          line_total: 890,
+          confidence: 0.41,
+        },
+      ],
+      confidence: 0.44,
+      low_confidence: true,
+      warnings: [
+        "Calidad de imagen baja. Se recomienda subir una foto mas clara.",
+      ],
+    };
+  }
+
+  return {
+    items: [
+      {
+        raw_description: "Harina 000 x 1kg",
+        line_total: 1450,
+        qty: 1,
+        unit: "kg",
+        confidence: 0.94,
+      },
+      {
+        raw_description: "Azucar x 1kg",
+        line_total: 1320,
+        qty: 1,
+        unit: "kg",
+        confidence: 0.92,
+      },
+      {
+        raw_description: "Leche entera x 1L",
+        line_total: 890,
+        qty: 1,
+        unit: "l",
+        confidence: 0.9,
+      },
+    ],
+    confidence: 0.9,
+    low_confidence: false,
+    warnings: [],
+  };
+}
+
+async function readFileNameFromRequest(request: Request): Promise<string | null> {
+  const contentType = request.headers.get("content-type") ?? "";
+
+  if (contentType.includes("multipart/form-data")) {
+    const formData = await request.formData();
+    const file = formData.get("file");
+
+    if (!(file instanceof File)) {
+      return null;
+    }
+
+    return file.name || "factura.jpg";
+  }
+
+  if (contentType.includes("application/json")) {
+    const payload = (await request.json()) as { fileName?: unknown };
+    if (typeof payload.fileName !== "string" || payload.fileName.trim() === "") {
+      return null;
+    }
+
+    return payload.fileName;
+  }
+
+  return null;
+}
+
+export async function POST(request: Request) {
+  try {
+    const fileName = await readFileNameFromRequest(request);
+
+    if (!fileName) {
+      return NextResponse.json(
+        {
+          error:
+            "Entrada invalida. Envie multipart/form-data con file o JSON con fileName.",
+        },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(buildMockResponse(fileName), { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: "No se pudo procesar la solicitud de parseo." },
+      { status: 400 }
+    );
+  }
+}


### PR DESCRIPTION
## Resumen\n- agrega route handler POST /api/parse-invoice\n- soporta entrada multipart/form-data (file) o JSON (ileName)\n- devuelve mock de items[] + confidence + low_confidence + warnings\n- simula caso de baja confianza cuando el nombre sugiere imagen de mala calidad\n- maneja input invalido con 400\n- agrega tests unitarios del endpoint\n\n## Issue\n- Closes #14\n- Relacionado con #12\n\n## Validacion\n- pnpm lint\n- pnpm test\n- pnpm build