### PR TITLE
feat: contrato tipado de parseo + tabla inicial de items

### DIFF
--- a/src/app/api/parse-invoice/route.test.ts
+++ b/src/app/api/parse-invoice/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { POST } from "@/app/api/parse-invoice/route";
+import type {
+  ParseInvoiceErrorResponse,
+  ParseInvoiceResponse,
+} from "@/domain/invoice-parse";
 
 describe("POST /api/parse-invoice", () => {
   it("devuelve items mock con confianza alta para factura clara", async () => {
@@ -13,11 +17,7 @@ describe("POST /api/parse-invoice", () => {
     });
 
     const response = await POST(request);
-    const payload = (await response.json()) as {
-      confidence: number;
-      low_confidence: boolean;
-      items: Array<{ raw_description: string }>;
-    };
+    const payload = (await response.json()) as ParseInvoiceResponse;
 
     expect(response.status).toBe(200);
     expect(payload.low_confidence).toBe(false);
@@ -35,10 +35,7 @@ describe("POST /api/parse-invoice", () => {
     });
 
     const response = await POST(request);
-    const payload = (await response.json()) as {
-      low_confidence: boolean;
-      warnings: string[];
-    };
+    const payload = (await response.json()) as ParseInvoiceResponse;
 
     expect(response.status).toBe(200);
     expect(payload.low_confidence).toBe(true);
@@ -55,7 +52,7 @@ describe("POST /api/parse-invoice", () => {
     });
 
     const response = await POST(request);
-    const payload = (await response.json()) as { error: string };
+    const payload = (await response.json()) as ParseInvoiceErrorResponse;
 
     expect(response.status).toBe(400);
     expect(payload.error).toMatch(/entrada invalida/i);

--- a/src/app/api/parse-invoice/route.ts
+++ b/src/app/api/parse-invoice/route.ts
@@ -1,21 +1,10 @@
 import { NextResponse } from "next/server";
+import {
+  isParseInvoiceRequestBody,
+  type ParseInvoiceResponse,
+} from "@/domain/invoice-parse";
 
-type MockInvoiceItem = {
-  raw_description: string;
-  line_total: number;
-  qty?: number;
-  unit?: string;
-  confidence?: number;
-};
-
-type ParseInvoiceMockResponse = {
-  items: MockInvoiceItem[];
-  confidence: number;
-  low_confidence: boolean;
-  warnings: string[];
-};
-
-function buildMockResponse(fileName: string): ParseInvoiceMockResponse {
+function buildMockResponse(fileName: string): ParseInvoiceResponse {
   const lowered = fileName.toLowerCase();
   const lowConfidence =
     lowered.includes("blurry") ||
@@ -90,12 +79,12 @@ async function readFileNameFromRequest(request: Request): Promise<string | null>
   }
 
   if (contentType.includes("application/json")) {
-    const payload = (await request.json()) as { fileName?: unknown };
-    if (typeof payload.fileName !== "string" || payload.fileName.trim() === "") {
+    const payload = await request.json();
+    if (!isParseInvoiceRequestBody(payload)) {
       return null;
     }
 
-    return payload.fileName;
+    return payload.fileName.trim();
   }
 
   return null;

--- a/src/domain/__tests__/invoice-parse.test.ts
+++ b/src/domain/__tests__/invoice-parse.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isParseInvoiceRequestBody,
+  isParseInvoiceResponse,
+  parseInvoiceResponse,
+} from "@/domain/invoice-parse";
+
+describe("invoice-parse contract", () => {
+  it("valida request body con fileName", () => {
+    expect(isParseInvoiceRequestBody({ fileName: "factura.jpg" })).toBe(true);
+    expect(isParseInvoiceRequestBody({ fileName: "   " })).toBe(false);
+    expect(isParseInvoiceRequestBody({})).toBe(false);
+  });
+
+  it("valida respuesta de parseo", () => {
+    const payload = {
+      items: [{ raw_description: "Harina", line_total: 1000, confidence: 0.8 }],
+      confidence: 0.8,
+      low_confidence: false,
+      warnings: [],
+    };
+
+    expect(isParseInvoiceResponse(payload)).toBe(true);
+    expect(parseInvoiceResponse(payload)).toEqual(payload);
+  });
+
+  it("rechaza payload invalido", () => {
+    const invalidPayload = {
+      items: [{ raw_description: "Leche", line_total: "890" }],
+      confidence: 0.7,
+      low_confidence: false,
+      warnings: [],
+    };
+
+    expect(isParseInvoiceResponse(invalidPayload)).toBe(false);
+    expect(() => parseInvoiceResponse(invalidPayload)).toThrow(/invalida/i);
+  });
+});

--- a/src/domain/invoice-parse.ts
+++ b/src/domain/invoice-parse.ts
@@ -1,0 +1,91 @@
+export type ParseInvoiceRequestBody = {
+  fileName: string;
+};
+
+export type ParseInvoiceItem = {
+  raw_description: string;
+  line_total: number;
+  qty?: number;
+  unit?: string;
+  confidence?: number;
+};
+
+export type ParseInvoiceResponse = {
+  items: ParseInvoiceItem[];
+  confidence: number;
+  low_confidence: boolean;
+  warnings: string[];
+};
+
+export type ParseInvoiceErrorResponse = {
+  error: string;
+};
+
+export function isParseInvoiceRequestBody(
+  value: unknown
+): value is ParseInvoiceRequestBody {
+  if (!isRecord(value)) return false;
+  return typeof value.fileName === "string" && value.fileName.trim() !== "";
+}
+
+export function isParseInvoiceResponse(
+  value: unknown
+): value is ParseInvoiceResponse {
+  if (!isRecord(value)) return false;
+
+  if (
+    !Array.isArray(value.items) ||
+    typeof value.confidence !== "number" ||
+    typeof value.low_confidence !== "boolean" ||
+    !Array.isArray(value.warnings)
+  ) {
+    return false;
+  }
+
+  if (!value.items.every(isParseInvoiceItem)) {
+    return false;
+  }
+
+  if (!value.warnings.every((warning) => typeof warning === "string")) {
+    return false;
+  }
+
+  return true;
+}
+
+export function parseInvoiceResponse(value: unknown): ParseInvoiceResponse {
+  if (!isParseInvoiceResponse(value)) {
+    throw new Error("Respuesta invalida del parseo de factura");
+  }
+
+  return value;
+}
+
+function isParseInvoiceItem(value: unknown): value is ParseInvoiceItem {
+  if (!isRecord(value)) return false;
+
+  if (
+    typeof value.raw_description !== "string" ||
+    typeof value.line_total !== "number"
+  ) {
+    return false;
+  }
+
+  if (value.qty !== undefined && typeof value.qty !== "number") {
+    return false;
+  }
+
+  if (value.unit !== undefined && typeof value.unit !== "string") {
+    return false;
+  }
+
+  if (value.confidence !== undefined && typeof value.confidence !== "number") {
+    return false;
+  }
+
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/ui/invoice/ParsedItemsTable.tsx
+++ b/src/ui/invoice/ParsedItemsTable.tsx
@@ -1,0 +1,87 @@
+import type { ParseInvoiceItem } from "@/domain/invoice-parse";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/ui/components/ui/card";
+
+type ParsedItemsTableProps = {
+  items: ParseInvoiceItem[];
+  isLoading: boolean;
+  error: string | null;
+  lowConfidence: boolean;
+};
+
+function formatConfidence(value: number | undefined) {
+  if (value === undefined) return "-";
+  return `${Math.round(value * 100)}%`;
+}
+
+export function ParsedItemsTable({
+  items,
+  isLoading,
+  error,
+  lowConfidence,
+}: ParsedItemsTableProps) {
+  return (
+    <Card className="lg:col-span-2">
+      <CardHeader>
+        <CardTitle>Items detectados (mock)</CardTitle>
+        <CardDescription>
+          Resultado preliminar para pasar luego a correccion manual.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading && (
+          <p className="text-sm text-info">Procesando imagen de factura...</p>
+        )}
+
+        {error && <p className="text-sm text-danger">{error}</p>}
+
+        {!isLoading && !error && items.length === 0 && (
+          <p className="text-sm text-muted">Aun no hay items detectados.</p>
+        )}
+
+        {lowConfidence && !isLoading && !error && items.length > 0 && (
+          <div className="rounded-xl border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+            Confianza baja detectada. Revisar manualmente cada item antes de guardar.
+          </div>
+        )}
+
+        {!isLoading && !error && items.length > 0 && (
+          <div className="overflow-x-auto rounded-2xl border border-border">
+            <table className="min-w-full text-sm">
+              <thead className="bg-surface-alt/70 text-left text-muted">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Descripcion</th>
+                  <th className="px-4 py-3 font-medium">Cantidad</th>
+                  <th className="px-4 py-3 font-medium">Unidad</th>
+                  <th className="px-4 py-3 font-medium">Total</th>
+                  <th className="px-4 py-3 font-medium">Confianza</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((item, index) => (
+                  <tr
+                    key={`${item.raw_description}-${index}`}
+                    className="border-t border-border"
+                  >
+                    <td className="px-4 py-3 text-text">{item.raw_description}</td>
+                    <td className="px-4 py-3 text-muted">{item.qty ?? "-"}</td>
+                    <td className="px-4 py-3 text-muted">{item.unit ?? "-"}</td>
+                    <td className="px-4 py-3 text-muted">{item.line_total}</td>
+                    <td className="px-4 py-3 text-muted">
+                      {formatConfidence(item.confidence)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Resumen\n- agrega contrato compartido de parseo de factura en src/domain/invoice-parse.ts\n- agrega validadores/guards para request y response\n- actualiza endpoint /api/parse-invoice para usar contrato tipado\n- actualiza UI de /factura para parsear respuesta con validacion centralizada\n- extrae tabla de items detectados a componente dedicado con estados (loading/empty/error/low confidence)\n\n## Issues\n- Closes #15\n- Closes #16\n\n## Validacion\n- pnpm lint\n- pnpm test\n- pnpm build