### PR TITLE
feat: hardening de cache en service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## PWA Cache Notes (Dev)
+
+This project registers a service worker (`public/sw.js`) with versioned caches.
+
+- When changing visual assets or caching logic, bump `SW_VERSION` in `public/sw.js`.
+- If your browser keeps showing stale UI during local development:
+  1. Open DevTools `Application` tab.
+  2. Go to `Service Workers` and unregister current worker.
+  3. Go to `Storage` and clear site data.
+  4. Reload the app.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,12 @@
-const CACHE_NAME = "subrecetas-static-v1";
+const SW_VERSION = "v2";
+const STATIC_CACHE = `subrecetas-static-${SW_VERSION}`;
+const RUNTIME_CACHE = `subrecetas-runtime-${SW_VERSION}`;
 const CORE_ASSETS = ["/", "/manifest.webmanifest", "/icon.svg", "/favicon.ico"];
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
     caches
-      .open(CACHE_NAME)
+      .open(STATIC_CACHE)
       .then((cache) => cache.addAll(CORE_ASSETS))
       .then(() => self.skipWaiting())
   );
@@ -12,35 +14,88 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys
-          .filter((key) => key !== CACHE_NAME)
-          .map((key) => caches.delete(key))
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter(
+              (key) =>
+                key.startsWith("subrecetas-static-") ||
+                key.startsWith("subrecetas-runtime-")
+            )
+            .filter((key) => key !== STATIC_CACHE && key !== RUNTIME_CACHE)
+            .map((key) => caches.delete(key))
+        )
       )
-    ).then(() => self.clients.claim())
+      .then(() => self.clients.claim())
   );
 });
 
 self.addEventListener("fetch", (event) => {
   if (event.request.method !== "GET") return;
+
   const url = new URL(event.request.url);
   if (url.origin !== self.location.origin) return;
 
   if (event.request.mode === "navigate") {
-    event.respondWith(
-      fetch(event.request)
-        .then((response) => {
-          const copy = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put("/", copy));
-          return response;
-        })
-        .catch(() => caches.match("/"))
-    );
+    event.respondWith(networkFirstNavigation(event.request));
     return;
   }
 
-  event.respondWith(
-    caches.match(event.request).then((cached) => cached || fetch(event.request))
-  );
+  if (isStaticAsset(url.pathname)) {
+    event.respondWith(staleWhileRevalidate(event.request));
+    return;
+  }
+
+  event.respondWith(cacheFirst(event.request));
 });
+
+async function networkFirstNavigation(request) {
+  try {
+    const response = await fetch(request);
+    const cache = await caches.open(RUNTIME_CACHE);
+    await cache.put(request, response.clone());
+    return response;
+  } catch {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) return cachedResponse;
+    const fallback = await caches.match("/");
+    return fallback || new Response("Offline", { status: 503 });
+  }
+}
+
+async function staleWhileRevalidate(request) {
+  const cache = await caches.open(RUNTIME_CACHE);
+  const cachedResponse = await cache.match(request);
+
+  const networkResponsePromise = fetch(request)
+    .then((response) => {
+      if (response && response.status === 200) {
+        cache.put(request, response.clone());
+      }
+      return response;
+    })
+    .catch(() => null);
+
+  return cachedResponse || networkResponsePromise || new Response("Offline", { status: 503 });
+}
+
+async function cacheFirst(request) {
+  const cachedResponse = await caches.match(request);
+  if (cachedResponse) return cachedResponse;
+
+  const response = await fetch(request);
+  const cache = await caches.open(RUNTIME_CACHE);
+  cache.put(request, response.clone());
+  return response;
+}
+
+function isStaticAsset(pathname) {
+  return (
+    pathname.startsWith("/_next/static/") ||
+    pathname === "/manifest.webmanifest" ||
+    pathname === "/icon.svg" ||
+    pathname === "/favicon.ico"
+  );
+}


### PR DESCRIPTION
## Resumen\n- versiona caches de SW con SW_VERSION\n- separa caches static y untime\n- limpieza de caches viejas al activar SW\n- estrategia 
etwork-first para navegacion\n- estrategia stale-while-revalidate para assets estaticos\n- fallback offline controlado\n- agrega notas de invalidacion en desarrollo en README\n\n## Issue\n- Closes #11\n\n## Validacion\n- pnpm lint\n- pnpm test\n- pnpm build